### PR TITLE
Allow passing a ClassLoader as parent for the isolated module class loader

### DIFF
--- a/slimjar/src/main/java/io/github/slimjar/app/ApplicationFactory.java
+++ b/slimjar/src/main/java/io/github/slimjar/app/ApplicationFactory.java
@@ -55,11 +55,15 @@ public final class ApplicationFactory {
     }
 
     public Application createIsolatedApplication(final Collection<String> moduleNames, final String fqClassName, final Object... args) throws ReflectiveOperationException, ClassCastException, IOException {
+        return createIsolatedApplication(moduleNames, fqClassName, ClassLoader.getSystemClassLoader().getParent(), args);
+    }
+
+    public Application createIsolatedApplication(final Collection<String> moduleNames, final String fqClassName, final ClassLoader parent, final Object... args) throws ReflectiveOperationException, ClassCastException, IOException {
         final Gson gson = new Gson();
         final ModuleExtractor moduleExtractor = new TemporaryModuleExtractor();
         final URL[] extractedModules = findExtractedModules(moduleExtractor, moduleNames);
         final DependencyDataProviderFactory dependencyDataProviderFactory = new DependencyDataProviderFactory(gson);
-        final InjectableClassLoader classLoader = new IsolatedInjectableClassLoader(extractedModules, Collections.singleton(Application.class), Collections.emptyList());
+        final InjectableClassLoader classLoader = new IsolatedInjectableClassLoader(extractedModules, parent, Collections.singleton(Application.class), Collections.emptyList());
         final DependencyInjector dependencyInjector = applicationConfiguration.getDependencyInjector();
 
         for (final URL module : extractedModules) {

--- a/slimjar/src/main/java/io/github/slimjar/injector/loader/IsolatedInjectableClassLoader.java
+++ b/slimjar/src/main/java/io/github/slimjar/injector/loader/IsolatedInjectableClassLoader.java
@@ -39,7 +39,11 @@ public class IsolatedInjectableClassLoader extends InjectableClassLoader {
     }
 
     public IsolatedInjectableClassLoader(final URL[] urls, final Collection<Class<?>> delegates, final Collection<String> openClassNames) {
-        super(urls, getSystemClassLoader().getParent());
+      this(urls, getSystemClassLoader().getParent(), delegates, openClassNames);
+    }
+
+    public IsolatedInjectableClassLoader(final URL[] urls, final ClassLoader parent, final Collection<Class<?>> delegates, final Collection<String> openClassNames) {
+        super(urls, parent);
         for (Class<?> clazz : delegates) {
             delegatesMap.put(clazz.getName(), clazz);
         }


### PR DESCRIPTION
This basically lets the isolated system to be "appended" to an existing running environment and maintain classes and reflection lookups to be maintained "upstream" when delegated.