### PR TITLE
Performance improvements to dependency resolution and caching

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     `java-gradle-plugin`
     `kotlin-dsl`
     `groovy`
-    kotlin("jvm") version "1.5.30"
+    kotlin("jvm") version "1.4.20"
     id("com.gradle.plugin-publish") version "0.12.0"
     id("com.github.johnrengelman.shadow") version "7.0.0"
     `maven-publish`

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     `java-gradle-plugin`
     `kotlin-dsl`
     `groovy`
-    kotlin("jvm") version "1.4.20"
+    kotlin("jvm") version "1.5.30"
     id("com.gradle.plugin-publish") version "0.12.0"
     id("com.github.johnrengelman.shadow") version "7.0.0"
     `maven-publish`
@@ -19,14 +19,13 @@ repositories {
     maven("https://plugins.gradle.org/m2/")
 }
 
-
-
 val shadowImplementation: Configuration by configurations.creating
 configurations["compileOnly"].extendsFrom(shadowImplementation)
 configurations["testImplementation"].extendsFrom(shadowImplementation)
 
 dependencies {
     shadowImplementation(kotlin("stdlib", "1.4.20"))
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2")
     shadowImplementation(project(":slimjar"))
     shadowImplementation("com.google.code.gson:gson:2.8.6")
 
@@ -104,6 +103,7 @@ tasks {
     withType<KotlinCompile> {
         kotlinOptions {
             jvmTarget = "1.8"
+            freeCompilerArgs = freeCompilerArgs + "-Xopt-in=kotlin.RequiresOptIn"
         }
     }
 

--- a/gradle-plugin/src/main/kotlin/io/github/slimjar/Interop.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/slimjar/Interop.kt
@@ -2,9 +2,10 @@ package io.github.slimjar
 
 import groovy.lang.Closure
 
-inline fun Any.asGroovyClosure(default: String, crossinline func: (arg: String) -> String): (String) -> String = object : Closure<String>(this), (String) -> String, () -> String {
-    fun doCall(arg: String) = func(arg)
-    fun doCall() = doCall(default)
-    override fun invoke(p1: String): String = doCall(p1)
-    override fun invoke(): String = invoke(default)
-}
+inline fun Any.asGroovyClosure(default: String, crossinline func: (arg: String) -> String): (String) -> String =
+    object : Closure<String>(this), (String) -> String, () -> String {
+        fun doCall(arg: String) = func(arg)
+        fun doCall() = doCall(default)
+        override fun invoke(p1: String): String = doCall(p1)
+        override fun invoke(): String = invoke(default)
+    }

--- a/gradle-plugin/src/main/kotlin/io/github/slimjar/task/SlimJar.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/slimjar/task/SlimJar.kt
@@ -202,7 +202,7 @@ abstract class SlimJar @Inject constructor(private val config: Configuration) : 
 
         val folder = outputDirectory
         val file = File(folder, "slimjar-resolutions.json")
-        file.delete()
+
         val mapType: Type = object : TypeToken<MutableMap<String, ResolutionResult>>() {}.type
         val preResolved: MutableMap<String, ResolutionResult> = if (file.exists()) {
             gson.fromJson(FileReader(file), mapType)
@@ -214,7 +214,6 @@ abstract class SlimJar @Inject constructor(private val config: Configuration) : 
             .mapNotNull {
                 it.toSlimDependency()
             }.toMutableSet().flatten()
-
 
         val repositories = repositories.filterIsInstance<MavenArtifactRepository>()
             .filterNot { it.url.toString().startsWith("file") }


### PR DESCRIPTION
This PR enables SlimJar to cache data to decrease build time.
Also switching to coroutines over parallelStream decreased resolution even more.

Some time comparisons with this PR using 12 dependencies (and transitive ones):
```yaml
[Clean compile]
1.3.0: 1m 2s
PR: 23s

[Add 1 dependency]
1.3.0: - # Same as clean
PR: 3s

[Remove 1 dependency]
1.3.0: - # Same as clean
PR: 3s

[No dependency change]
1.3.0: - # Same as clean
PR: UP-TO-DATE 5ms
```